### PR TITLE
fix: #46 이메일 인증 버그 수정

### DIFF
--- a/docs/supabase-email-template.md
+++ b/docs/supabase-email-template.md
@@ -20,65 +20,74 @@
 ```html
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>B0 이메일 인증</title>
-</head>
-<body style="margin: 0; padding: 0; background-color: #f4f5f7; font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', dotum, sans-serif; line-height: 1.6;">
-    
-    <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 4px 10px rgba(0,0,0,0.1);">
-        
-        <tr>
-            <td style="background-color: #2b2e4a; padding: 40px 20px; text-align: center;">
-                <h1 style="color: #ffffff; margin: 0; font-size: 28px; font-weight: 700; letter-spacing: 2px;">B0 : 지하 0층</h1>
-                <p style="color: #aeb4d1; margin: 10px 0 0 0; font-size: 14px;">일상 아래 숨겨진 당신만의 휴식처</p>
-            </td>
-        </tr>
+  </head>
+  <body
+    style="margin: 0; padding: 0; background-color: #f4f5f7; font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', dotum, sans-serif; line-height: 1.6;"
+  >
+    <table
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      width="100%"
+      style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 4px 10px rgba(0,0,0,0.1);"
+    >
+      <tr>
+        <td style="background-color: #2b2e4a; padding: 40px 20px; text-align: center;">
+          <h1 style="color: #ffffff; margin: 0; font-size: 28px; font-weight: 700; letter-spacing: 2px;">
+            B0 : 지하 0층
+          </h1>
+          <p style="color: #aeb4d1; margin: 10px 0 0 0; font-size: 14px;">일상 아래 숨겨진 당신만의 휴식처</p>
+        </td>
+      </tr>
 
-        <tr>
-            <td style="padding: 40px 30px; color: #333333;">
-                <h2 style="font-size: 20px; color: #2b2e4a; margin-bottom: 20px;">안녕하세요, 여행자님! 🎈</h2>
-                
-                <p style="margin-bottom: 20px;">
-                    우연히 발견한 <strong>지하 0층(B0)</strong>에 오신 것을 환영합니다.<br>
-                    이곳은 일상에 지친 당신을 위해 준비된 비밀스러운 비행선 터미널입니다.
-                </p>
-                
-                <p style="margin-bottom: 30px;">
-                    지금 비행선이 이세계 도시들로 떠날 준비를 마쳤습니다.<br>
-                    아래 버튼을 눌러 <strong>이메일 인증</strong>을 완료하고,<br>
-                    새로운 사람들과의 만남과 깊은 휴식을 시작해 보세요.
-                </p>
+      <tr>
+        <td style="padding: 40px 30px; color: #333333;">
+          <h2 style="font-size: 20px; color: #2b2e4a; margin-bottom: 20px;">안녕하세요, 여행자님! 🎈</h2>
 
-                <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                    <tr>
-                        <td align="center" style="padding: 20px 0 40px 0;">
-                            <a href="{{ .ConfirmationURL }}" target="_blank" style="background-color: #536dfe; color: #ffffff; padding: 16px 40px; text-decoration: none; border-radius: 50px; font-weight: bold; font-size: 16px; display: inline-block; box-shadow: 0 4px 6px rgba(83, 109, 254, 0.3);">
-                                탑승 수속 완료하기
-                            </a>
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
+          <p style="margin-bottom: 20px;">
+            우연히 발견한 <strong>지하 0층(B0)</strong>에 오신 것을 환영합니다.<br />
+            이곳은 일상에 지친 당신을 위해 준비된 비밀스러운 비행선 터미널입니다.
+          </p>
 
-        <tr>
-            <td style="background-color: #f8f9fa; padding: 30px; text-align: center; border-top: 1px solid #eeeeee;">
-                <p style="font-size: 12px; color: #999999; margin: 0 0 10px 0;">
-                    본 메일은 B0 가입 인증을 위해 발송되었습니다.<br>
-                    본인이 요청하지 않았다면 이 메일을 무시해 주세요.
-                </p>
-                <p style="font-size: 12px; color: #bbbbbb; margin: 0;">
-                    © B0 Team. All rights reserved.
-                </p>
-            </td>
-        </tr>
+          <p style="margin-bottom: 30px;">
+            지금 비행선이 이세계 도시들로 떠날 준비를 마쳤습니다.<br />
+            아래 버튼을 눌러 <strong>이메일 인증</strong>을 완료하고,<br />
+            새로운 사람들과의 만남과 깊은 휴식을 시작해 보세요.
+          </p>
+
+          <table border="0" cellpadding="0" cellspacing="0" width="100%">
+            <tr>
+              <td align="center" style="padding: 20px 0 40px 0;">
+                <a
+                  href="{{ .ConfirmationURL }}"
+                  target="_blank"
+                  style="background-color: #536dfe; color: #ffffff; padding: 16px 40px; text-decoration: none; border-radius: 50px; font-weight: bold; font-size: 16px; display: inline-block; box-shadow: 0 4px 6px rgba(83, 109, 254, 0.3);"
+                >
+                  탑승 수속 완료하기
+                </a>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+
+      <tr>
+        <td style="background-color: #f8f9fa; padding: 30px; text-align: center; border-top: 1px solid #eeeeee;">
+          <p style="font-size: 12px; color: #999999; margin: 0 0 10px 0;">
+            본 메일은 B0 가입 인증을 위해 발송되었습니다.<br />
+            본인이 요청하지 않았다면 이 메일을 무시해 주세요.
+          </p>
+          <p style="font-size: 12px; color: #bbbbbb; margin: 0;">© B0 Team. All rights reserved.</p>
+        </td>
+      </tr>
     </table>
-    
-    <div style="height: 40px;"></div>
 
-</body>
+    <div style="height: 40px;"></div>
+  </body>
 </html>
 ```
 
@@ -95,3 +104,21 @@
 
 1. **Save** 버튼 클릭
 2. 테스트 회원가입으로 이메일 템플릿 확인
+
+## 이메일 인증 후 리다이렉트 설정
+
+이메일 인증 완료 후 사용자를 `/auth/email-confirmed` 페이지로 리다이렉트하려면, 회원가입 시 `emailRedirectTo` 옵션을 사용합니다.
+
+**코드 위치**: `src/api/auth.ts`의 `signUp` 함수
+
+```typescript
+const { data, error } = await supabase.auth.signUp({
+  email,
+  password,
+  options: {
+    emailRedirectTo: `${window.location.origin}/auth/email-confirmed`,
+  },
+});
+```
+
+이 설정으로 이메일 인증 링크 클릭 시 자동으로 `/auth/email-confirmed` 페이지로 리다이렉트됩니다.

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -10,8 +10,23 @@ import type { AuthCredentials } from "@/types.ts";
  *
  * 회원가입 후 이메일 인증이 필요함
  */
+/**
+ * 이메일/비밀번호로 회원가입
+ *
+ * 회원가입 후 이메일 인증이 필요함
+ * 이메일 인증 완료 후 emailRedirectTo로 리다이렉트됨
+ */
 export async function signUp({ email, password }: AuthCredentials): Promise<AuthResponse["data"]> {
-  const { data, error } = await supabase.auth.signUp({ email, password });
+  // 이메일 인증 완료 후 리다이렉트할 URL
+  const emailRedirectTo = `${window.location.origin}/auth/email-confirmed`;
+
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      emailRedirectTo,
+    },
+  });
 
   if (error) throw error;
 

--- a/src/components/email-status-message.tsx
+++ b/src/components/email-status-message.tsx
@@ -1,0 +1,27 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface EmailStatusMessageProps {
+  icon: LucideIcon;
+  iconClassName?: string;
+  title: string;
+  children: ReactNode;
+}
+
+/**
+ * 이메일 인증 상태 메시지 컴포넌트
+ *
+ * 이메일 인증 관련 페이지에서 상태별 메시지를 표시할 때 사용
+ * 아이콘, 제목, 설명으로 구성된 중앙 정렬 레이아웃
+ */
+export function EmailStatusMessage({ icon: Icon, iconClassName, title, children }: EmailStatusMessageProps) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-8 py-8">
+      <Icon className={iconClassName} />
+      <div className="flex flex-col gap-2 text-center">
+        <h2 className="text-xl font-bold">{title}</h2>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -16,6 +16,8 @@ export const ROUTES = {
   SIGN_UP: "/auth/sign-up",
   /** 이메일 인증 안내 페이지 */
   EMAIL_VERIFICATION: "/auth/email-verification",
+  /** 이메일 인증 완료 페이지 */
+  EMAIL_CONFIRMED: "/auth/email-confirmed",
   /** 프로필 완성 페이지 (닉네임, 이모지 설정) */
   PROFILE_COMPLETION: "/profile-completion",
   /** B0 비행선 터미널 홈 */

--- a/src/pages/email-confirmed-page.tsx
+++ b/src/pages/email-confirmed-page.tsx
@@ -1,0 +1,67 @@
+import { CheckCircle2Icon, LoaderCircleIcon, XCircleIcon } from "lucide-react";
+import { EmailStatusMessage } from "@/components/email-status-message.tsx";
+import { useEffect, useState } from "react";
+import supabase from "@/lib/supabase.ts";
+
+/**
+ * 이메일 인증 완료 페이지
+ *
+ * Supabase 이메일 인증 링크를 통해 리다이렉트된 후 표시되는 페이지
+ * URL 해시에서 토큰을 파싱하여 세션을 생성하고 사용자에게 안내
+ */
+export default function EmailConfirmedPage() {
+  const [status, setStatus] = useState<"checking" | "success" | "error">("checking");
+
+  useEffect(() => {
+    const checkSession = async () => {
+      try {
+        // Supabase가 URL 해시를 자동으로 파싱하여 세션 생성
+        // 약간의 지연을 두고 세션 확인
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+
+        if (session && session.user.email_confirmed_at) {
+          setStatus("success");
+        } else {
+          setStatus("error");
+        }
+      } catch (error) {
+        console.error("세션 확인 중 오류:", error);
+        setStatus("error");
+      }
+    };
+
+    checkSession();
+  }, []);
+
+  if (status === "checking") {
+    return (
+      <EmailStatusMessage
+        icon={LoaderCircleIcon}
+        iconClassName="text-primary size-16 animate-spin"
+        title="인증 처리 중..."
+      >
+        <p className="text-muted-foreground">잠시만 기다려주세요.</p>
+      </EmailStatusMessage>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <EmailStatusMessage icon={XCircleIcon} iconClassName="text-destructive size-16" title="인증 처리 실패">
+        <p className="text-muted-foreground">인증 링크가 만료되었거나 잘못되었습니다.</p>
+        <p className="text-muted-foreground">다시 시도해주세요.</p>
+      </EmailStatusMessage>
+    );
+  }
+
+  return (
+    <EmailStatusMessage icon={CheckCircle2Icon} iconClassName="text-primary size-16" title="이메일 인증 완료!">
+      <p className="text-muted-foreground">인증이 성공적으로 완료되었습니다.</p>
+      <p className="text-muted-foreground">이 탭을 닫고 앱으로 돌아가주세요.</p>
+    </EmailStatusMessage>
+  );
+}

--- a/src/pages/email-verification-page.tsx
+++ b/src/pages/email-verification-page.tsx
@@ -1,13 +1,56 @@
 import { LoaderPinwheelIcon } from "lucide-react";
 import { Button } from "@/components/ui/button.tsx";
-import { useNavigate } from "react-router";
+import { useState } from "react";
+import { useLocation, useNavigate } from "react-router";
+import supabase from "@/lib/supabase.ts";
+import { toast } from "sonner";
 import { ROUTES } from "@/lib/routes.ts";
 
 export default function EmailVerificationPage() {
+  const [isChecking, setIsChecking] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
 
-  const handleCompleteClicked = () => {
-    navigate(ROUTES.HOME);
+  // 회원가입 페이지에서 전달받은 이메일과 비밀번호
+  const { email, password } = (location.state as { email?: string; password?: string }) || {};
+
+  const handleCompleteClicked = async () => {
+    // 이메일/비밀번호가 없으면 (직접 URL 접근 시)
+    if (!email || !password) {
+      toast.error("회원가입 페이지에서 다시 시작해주세요.");
+      navigate(ROUTES.SIGN_UP, { replace: true });
+      return;
+    }
+
+    setIsChecking(true);
+
+    try {
+      // 로그인 시도로 이메일 인증 완료 여부 확인
+      const { data, error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+
+      if (error) {
+        // email_not_confirmed 에러 = 아직 이메일 인증 안됨
+        if (error.code === "email_not_confirmed") {
+          toast.error("아직 이메일 인증이 완료되지 않았습니다. 이메일을 확인해주세요.");
+        } else {
+          throw error;
+        }
+        return;
+      }
+
+      // 로그인 성공 = 이메일 인증 완료
+      if (data.session) {
+        navigate(ROUTES.HOME, { replace: true });
+      }
+    } catch (error) {
+      console.error("인증 확인 중 오류 발생:", error);
+      toast.error("인증 확인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+    } finally {
+      setIsChecking(false);
+    }
   };
 
   return (
@@ -19,8 +62,8 @@ export default function EmailVerificationPage() {
           <p>인증을 완료해주세요.</p>
         </div>
       </div>
-      <Button className="w-full py-6 text-lg" onClick={handleCompleteClicked}>
-        인증 완료
+      <Button className="w-full py-6 text-lg" onClick={handleCompleteClicked} disabled={isChecking}>
+        {isChecking ? "확인 중..." : "인증 완료"}
       </Button>
     </div>
   );

--- a/src/pages/sign-up-page.tsx
+++ b/src/pages/sign-up-page.tsx
@@ -16,7 +16,11 @@ export default function SignUpPage() {
   const navigate = useNavigate();
   const { mutate: signUp, isPending } = useSignUp({
     onSuccess: () => {
-      navigate(ROUTES.EMAIL_VERIFICATION, { replace: true });
+      // 이메일 인증 페이지로 이메일과 비밀번호 전달
+      navigate(ROUTES.EMAIL_VERIFICATION, {
+        replace: true,
+        state: { email, password },
+      });
     },
     onError: (e: AuthError) => {
       toast.error(generateAuthErrorMessage(e));

--- a/src/root-route.tsx
+++ b/src/root-route.tsx
@@ -12,6 +12,7 @@ import GuestGuard from "@/components/guards/guest-guard.tsx";
 import AuthGuard from "@/components/guards/auth-guard.tsx";
 import AuthPage from "@/pages/auth-page.tsx";
 import EmailVerificationPage from "@/pages/email-verification-page.tsx";
+import EmailConfirmedPage from "@/pages/email-confirmed-page.tsx";
 import { ROUTES } from "@/lib/routes.ts";
 
 export const router = createBrowserRouter([
@@ -49,6 +50,11 @@ export const router = createBrowserRouter([
                 handle: { title: "이메일 확인", isRoot: true },
               },
             ],
+          },
+          {
+            path: ROUTES.EMAIL_CONFIRMED,
+            element: <EmailConfirmedPage />,
+            handle: { title: "인증 완료", isRoot: true },
           },
           {
             element: <AuthGuard />,


### PR DESCRIPTION
## Summary

이메일 인증 관련 3가지 버그를 수정했습니다.

### 수정된 버그

1. **"인증 완료" 버튼 클릭 시 에러 처리 개선**
   - 이메일 인증 전 "인증 완료" 버튼 클릭 시 적절한 에러 메시지 표시
   - 로그인 시도를 통한 인증 상태 확인 방식으로 변경

2. **이메일 인증 링크 클릭 시 확인 페이지 표시**
   - 새로운 `/auth/email-confirmed` 페이지 추가
   - Supabase 세션 자동 생성 후 인증 성공/실패 상태 표시

3. **인증 완료 후 일관된 리다이렉션**
   - 인증 완료 버튼 클릭 시 프로필 완성 페이지로 정확히 이동
   - 크로스 브라우저 환경에서도 정상 동작

### 주요 변경사항

- **API 수정**: `signUp` 함수에 `emailRedirectTo` 옵션 추가
- **새 페이지**: `EmailConfirmedPage` - 이메일 인증 완료 페이지
- **컴포넌트 추출**: `EmailStatusMessage` - 재사용 가능한 상태 메시지 컴포넌트
- **라우팅**: `/auth/email-confirmed` 경로를 AuthGuard 외부로 이동
- **인증 로직**: 로그인 시도로 이메일 인증 상태 확인 (크로스 브라우저 지원)
- **문서 업데이트**: Supabase 이메일 템플릿 설정 가이드 개선

### 기술적 해결 방법

- **크로스 브라우저 문제 해결**: 회원가입 시 이메일/비밀번호를 navigation state로 전달하고, "인증 완료" 버튼 클릭 시 `signInWithPassword()`로 인증 상태 확인
- **세션 생성**: 이메일 링크 클릭 시 Supabase가 URL 해시 토큰을 파싱하여 자동으로 세션 생성
- **컴포넌트 재사용**: 이메일 관련 상태 메시지 UI 패턴을 `EmailStatusMessage` 컴포넌트로 추출

## Test plan

- [x] A 브라우저에서 회원가입
- [x] B 브라우저에서 이메일 인증 링크 클릭
- [x] A 브라우저로 돌아와 "인증 완료" 버튼 클릭
- [x] 프로필 완성 페이지로 정상 이동 확인
- [x] 인증 전 "인증 완료" 버튼 클릭 시 적절한 에러 메시지 표시 확인
- [x] 이메일 링크 클릭 시 인증 완료 페이지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>