### PR TITLE
feat: 개인 숙소 체크아웃 및 체류 연장 기능 추가

### DIFF
--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -415,9 +415,13 @@
 
 ### API 연동
 
-- [ ] 체류 연장 API 호출
-- [ ] 체크아웃 시간 조회
-- [ ] 자동 체크아웃 감지 (폴링 또는 WebSocket)
+- [ ] POST /api/v1/room-stays/current/extend - 체류 연장
+- [ ] GET /api/v1/room-stays/current - 현재 체류 정보 조회 (scheduled_checkout_at 포함)
+- [ ] 자동 체크아웃 감지:
+  - [ ] 주기적 폴링 (30초~1분 간격) 또는 Socket.IO 이벤트
+  - [ ] 백엔드 배치 작업은 10분 주기로 실행되므로, 최대 10분 지연 가능
+- [ ] GET /api/v1/notifications - 알림 목록 조회
+- [ ] PATCH /api/v1/notifications/{id}/read - 알림 읽음 처리
 
 ### 완료 조건
 

--- a/src/api/room-stays.ts
+++ b/src/api/room-stays.ts
@@ -14,3 +14,19 @@ export async function getCurrentRoomStay(): Promise<RoomStay> {
   const { data } = await apiClient.get<DataResponse<RoomStay>>("/room-stays/current");
   return data.data;
 }
+
+/**
+ * 현재 체류를 체크아웃합니다.
+ */
+export async function checkoutCurrentStay(): Promise<RoomStay> {
+  const { data } = await apiClient.post<DataResponse<RoomStay>>("/room-stays/current/checkout");
+  return data.data;
+}
+
+/**
+ * 현재 체류를 연장합니다. (300포인트 차감, 24시간 연장)
+ */
+export async function extendCurrentStay(): Promise<RoomStay> {
+  const { data } = await apiClient.post<DataResponse<RoomStay>>("/room-stays/current/extend");
+  return data.data;
+}

--- a/src/components/ExtendStayModal.tsx
+++ b/src/components/ExtendStayModal.tsx
@@ -1,0 +1,88 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { extendCurrentStay } from "@/api/room-stays";
+import { toast } from "sonner";
+import { queryKeys } from "@/lib/query-client";
+import type { B0ApiError } from "@/lib/api-errors";
+
+interface ExtendStayModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentCheckOut?: string;
+}
+
+export default function ExtendStayModal({ open, onOpenChange, currentCheckOut }: ExtendStayModalProps) {
+  const queryClient = useQueryClient();
+
+  const { mutate: extend, isPending } = useMutation({
+    mutationFn: extendCurrentStay,
+    onSuccess: (data) => {
+      toast.success("체류가 1일 연장되었습니다.");
+      queryClient.setQueryData(queryKeys.roomStays.current, data);
+      onOpenChange(false);
+    },
+    onError: (error: B0ApiError) => {
+      if (error.code === "INSUFFICIENT_BALANCE") {
+        toast.error("포인트가 부족합니다. (필요: 300P)");
+      } else {
+        toast.error(error.message || "연장 실패");
+      }
+    },
+  });
+
+  const handleExtend = () => {
+    extend();
+  };
+
+  const getNewCheckOutDate = () => {
+    if (!currentCheckOut) return "";
+    const date = new Date(currentCheckOut);
+    date.setDate(date.getDate() + 1);
+    return date.toLocaleString();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>체류 기간 연장</DialogTitle>
+          <DialogDescription>
+            체류를 1일(24시간) 연장하시겠습니까?
+            <br />
+            <span className="font-bold text-indigo-500">300 포인트</span>가 차감됩니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        {currentCheckOut && (
+          <div className="grid gap-2 py-4">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-zinc-500">현재 체크아웃 시간</span>
+              <span className="font-medium">{new Date(currentCheckOut).toLocaleString()}</span>
+            </div>
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-zinc-500">연장 후 체크아웃 시간</span>
+              <span className="font-bold text-indigo-500">{getNewCheckOutDate()}</span>
+            </div>
+          </div>
+        )}
+
+        <DialogFooter className="sm:justify-end">
+          <Button variant="secondary" onClick={() => onOpenChange(false)}>
+            취소
+          </Button>
+          <Button onClick={handleExtend} disabled={isPending} className="bg-indigo-600 hover:bg-indigo-700">
+            {isPending ? "연장 중..." : "300P로 연장하기"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/private-room-page.tsx
+++ b/src/pages/private-room-page.tsx
@@ -2,10 +2,47 @@ import img_bg_private_room from "@/assets/images/img_bg_private_room.webp";
 import { Button } from "@/components/ui/button.tsx";
 import { buildPath } from "@/lib/routes.ts";
 import { useNavigate, useParams } from "react-router";
+import { useCurrentRoomStay } from "@/hooks/queries/use-current-room-stay.ts";
+import { checkoutCurrentStay } from "@/api/room-stays.ts";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/query-client.ts";
+import type { B0ApiError } from "@/lib/api-errors";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog.tsx";
+import { useCallback, useEffect, useState } from "react";
+import ExtendStayModal from "@/components/ExtendStayModal";
 
 export default function PrivateRoomPage() {
   const navigate = useNavigate();
   const { guesthouseId } = useParams<{ guesthouseId: string }>();
+  const queryClient = useQueryClient();
+  const [isExtendModalOpen, setIsExtendModalOpen] = useState(false);
+
+  // 현재 체류 정보 조회
+  const { data: roomStay, isLoading } = useCurrentRoomStay();
+
+  // 체크아웃 뮤테이션
+  const { mutate: checkout, isPending: isCheckingOut } = useMutation({
+    mutationFn: checkoutCurrentStay,
+    onSuccess: () => {
+      toast.success("체크아웃 되었습니다.");
+      queryClient.setQueryData(queryKeys.roomStays.current, null); // 캐시 초기화
+      handleBackClick();
+    },
+    onError: (error: B0ApiError) => {
+      toast.error(error.message || "체크아웃 실패");
+    },
+  });
 
   const handleDiaryClick = () => {
     if (!guesthouseId) return;
@@ -17,10 +54,54 @@ export default function PrivateRoomPage() {
     navigate(buildPath.questionnaire(guesthouseId));
   };
 
-  const handleBackClick = () => {
+  const handleBackClick = useCallback(() => {
     if (!guesthouseId) return;
     navigate(buildPath.guesthouse(guesthouseId));
+  }, [guesthouseId, navigate]);
+
+  const handleCheckout = () => {
+    checkout();
   };
+
+  // 실시간 현재 시간 (1초마다 갱신)
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  // 자동 리다이렉트 및 만료 감지
+  useEffect(() => {
+    if (isLoading) return;
+
+    // 체류 정보가 없으면 로비로 이동
+    if (!roomStay) {
+      handleBackClick();
+      return;
+    }
+
+    // 만료 시간 체크
+    const checkOutTime = new Date(roomStay.scheduled_check_out_at).getTime();
+    if (now > checkOutTime) {
+      toast.warning("퇴실 시간이 되어 자동 체크아웃 되었습니다.");
+      handleBackClick();
+    }
+  }, [roomStay, isLoading, now, handleBackClick]); // now가 바뀔 때마다 체크
+
+  // 남은 시간 계산 (1시간 미만 경고용)
+  const getTimeRemaining = () => {
+    if (!roomStay) return null;
+    const end = new Date(roomStay.scheduled_check_out_at).getTime();
+    const diff = end - now;
+    return diff > 0 ? diff : 0;
+  };
+
+  const remainingMs = getTimeRemaining();
+  // 1시간 미만이고, 만료되지 않았을 때만 임박 표시
+  const isImminent = remainingMs !== null && remainingMs < 60 * 60 * 1000 && remainingMs > 0;
 
   return (
     <div className="relative flex h-full w-full flex-col">
@@ -28,12 +109,56 @@ export default function PrivateRoomPage() {
       <img className="absolute inset-0 h-full w-full object-cover" src={img_bg_private_room} alt="개인 숙소 배경" />
       <div className="absolute inset-0 bg-black/60" />
 
-      {/* 헤더 (뒤로가기) */}
-      <div className="relative z-10 flex h-14 items-center px-4">
+      {/* 헤더 */}
+      <div className="relative z-10 flex h-14 items-center justify-between px-4">
         <Button variant="ghost" className="text-white hover:bg-white/10" onClick={handleBackClick}>
           ← 돌아가기
         </Button>
+
+        {/* 체크아웃 버튼 (AlertDialog) */}
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="ghost"
+              className="text-red-400 hover:bg-white/10 hover:text-red-300"
+              disabled={isCheckingOut}
+            >
+              {isCheckingOut ? "처리 중..." : "체크아웃"}
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>체크아웃 하시겠습니까?</AlertDialogTitle>
+              <AlertDialogDescription>현재 방에서 퇴실하며, 남은 시간은 저장되지 않습니다.</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>취소</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleCheckout}
+                className="bg-red-500 hover:bg-red-600"
+                disabled={isCheckingOut}
+              >
+                체크아웃
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
+
+      {/* 임박 알림 배너 */}
+      {isImminent && (
+        <div className="relative z-20 mx-4 mt-2 flex items-center justify-between rounded-lg bg-red-500/80 px-4 py-2 text-white backdrop-blur-sm">
+          <span className="text-sm font-medium">체크아웃까지 {Math.ceil(remainingMs! / 1000 / 60)}분 남았습니다!</span>
+          <Button
+            size="sm"
+            variant="secondary"
+            className="h-8 bg-white text-xs text-red-500 hover:bg-white/90"
+            onClick={() => setIsExtendModalOpen(true)}
+          >
+            연장하기
+          </Button>
+        </div>
+      )}
 
       {/* 메인 컨텐츠 (대시보드) */}
       <div className="relative z-10 flex flex-1 flex-col items-center justify-center gap-8 px-6 pb-20">
@@ -49,6 +174,12 @@ export default function PrivateRoomPage() {
           <DashboardCard title="문답지" description="나를 찾아가는 질문" icon="💭" onClick={handleQuestionnaireClick} />
         </div>
       </div>
+
+      <ExtendStayModal
+        open={isExtendModalOpen}
+        onOpenChange={setIsExtendModalOpen}
+        currentCheckOut={roomStay?.scheduled_check_out_at}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

개인 숙소에서 체크아웃 및 체류 연장 기능을 구현했습니다.

### 주요 변경사항

- **체크아웃 기능**
  - 개인 숙소 페이지에 체크아웃 버튼 추가
  - AlertDialog로 체크아웃 확인 UI 구현
  - 체크아웃 시 자동으로 게스트하우스 로비로 이동

- **체류 연장 기능**
  - ExtendStayModal 컴포넌트 추가 (300포인트로 24시간 연장)
  - 체류 시간 만료 1시간 전 임박 알림 배너 표시
  - 배너에서 바로 연장하기 버튼 제공

- **자동 체크아웃 감지**
  - 실시간(1초 간격) 남은 시간 체크
  - 체류 시간 만료 시 자동으로 로비로 이동 및 알림 표시
  - 체류 정보가 없을 경우 자동 리다이렉트

- **API 함수 추가**
  - `checkoutCurrentStay()`: 현재 체류 체크아웃
  - `extendCurrentStay()`: 현재 체류 연장 (300P, 24시간)

### 파일 변경

- `src/api/room-stays.ts`: 체크아웃/연장 API 함수 추가
- `src/pages/private-room-page.tsx`: 체크아웃 및 연장 UI/로직 구현
- `src/components/ExtendStayModal.tsx`: 체류 연장 모달 컴포넌트 추가
- `docs/checklist.md`: 체크아웃 관련 API 명세 문서화

## Test plan

- [ ] 개인 숙소 페이지에서 체크아웃 버튼 클릭 시 AlertDialog 표시 확인
- [ ] 체크아웃 실행 후 게스트하우스 로비로 이동 확인
- [ ] 체류 시간 만료 1시간 전 임박 알림 배너 표시 확인
- [ ] 임박 알림 배너에서 연장하기 버튼 클릭 시 ExtendStayModal 표시 확인
- [ ] 체류 연장 성공 시 체크아웃 시간 업데이트 및 포인트 차감 확인
- [ ] 체류 시간 만료 시 자동으로 로비 이동 및 알림 표시 확인
- [ ] 체류 정보가 없을 경우 자동 리다이렉트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)