### PR TITLE
feat: 체류 연장 UI 개선

### DIFF
--- a/src/pages/guesthouse-page.tsx
+++ b/src/pages/guesthouse-page.tsx
@@ -2,13 +2,14 @@ import { Button } from "@/components/ui/button.tsx";
 import { CityBadge } from "@/components/guesthouse/city-badge.tsx";
 import { SpaceList } from "@/components/guesthouse/space-list.tsx";
 import GlobalLoader from "@/components/global-loader.tsx";
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router";
 import { useCurrentRoomStay } from "@/hooks/queries/use-current-room-stay.ts";
 import { useCity } from "@/hooks/queries/use-city.ts";
 import { ROUTES } from "@/lib/routes.ts";
-import { toast } from "sonner";
+
 import { formatCheckoutTime } from "@/lib/date-utils.ts";
+import ExtendStayModal from "@/components/ExtendStayModal";
 
 import img_bg_city from "@/assets/images/img_bg_city.webp";
 
@@ -22,6 +23,7 @@ import img_bg_city from "@/assets/images/img_bg_city.webp";
  */
 export default function GuesthousePage() {
   const navigate = useNavigate();
+  const [isExtendModalOpen, setIsExtendModalOpen] = useState(false);
 
   // 현재 체류 정보 조회
   const { data: roomStay, isLoading: isRoomStayLoading, isError: isRoomStayError } = useCurrentRoomStay();
@@ -40,7 +42,7 @@ export default function GuesthousePage() {
 
   // 연장하기 버튼 핸들러
   const handleExtendClick = () => {
-    toast.info("연장하기 기능은 준비 중입니다.");
+    setIsExtendModalOpen(true);
   };
 
   // 로딩 중
@@ -86,6 +88,12 @@ export default function GuesthousePage() {
           연장하기 300P
         </Button>
       </div>
+
+      <ExtendStayModal
+        open={isExtendModalOpen}
+        onOpenChange={setIsExtendModalOpen}
+        currentCheckOut={roomStay.scheduled_check_out_at}
+      />
     </div>
   );
 }

--- a/src/pages/private-room-page.tsx
+++ b/src/pages/private-room-page.tsx
@@ -115,34 +115,45 @@ export default function PrivateRoomPage() {
           ← 돌아가기
         </Button>
 
-        {/* 체크아웃 버튼 (AlertDialog) */}
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button
-              variant="ghost"
-              className="text-red-400 hover:bg-white/10 hover:text-red-300"
-              disabled={isCheckingOut}
-            >
-              {isCheckingOut ? "처리 중..." : "체크아웃"}
-            </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>체크아웃 하시겠습니까?</AlertDialogTitle>
-              <AlertDialogDescription>현재 방에서 퇴실하며, 남은 시간은 저장되지 않습니다.</AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>취소</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={handleCheckout}
-                className="bg-red-500 hover:bg-red-600"
+        <div className="flex items-center gap-2">
+          {/* 연장하기 버튼 (상시 노출) */}
+          <Button
+            variant="ghost"
+            className="text-indigo-300 hover:bg-white/10 hover:text-indigo-200"
+            onClick={() => setIsExtendModalOpen(true)}
+          >
+            연장하기
+          </Button>
+
+          {/* 체크아웃 버튼 (AlertDialog) */}
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button
+                variant="ghost"
+                className="text-red-400 hover:bg-white/10 hover:text-red-300"
                 disabled={isCheckingOut}
               >
-                체크아웃
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+                {isCheckingOut ? "처리 중..." : "체크아웃"}
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>체크아웃 하시겠습니까?</AlertDialogTitle>
+                <AlertDialogDescription>현재 방에서 퇴실하며, 남은 시간은 저장되지 않습니다.</AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>취소</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={handleCheckout}
+                  className="bg-red-500 hover:bg-red-600"
+                  disabled={isCheckingOut}
+                >
+                  체크아웃
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
       </div>
 
       {/* 임박 알림 배너 */}


### PR DESCRIPTION
## Summary

게스트하우스 및 개인 숙소 페이지의 체류 연장 UI를 개선했습니다.

### 주요 변경사항

#### 게스트하우스 페이지
- **연장하기 버튼 개선**
  - 기존: "연장하기 기능은 준비 중입니다" 토스트 메시지
  - 개선: 버튼 클릭 시 ExtendStayModal 열림
  - ExtendStayModal에서 포인트 차감 및 연장 확인 가능

#### 개인 숙소 페이지
- **헤더 연장하기 버튼 추가**
  - 헤더에 연장하기 버튼 상시 노출
  - 1시간 미만 임박 알림 배너와 별도로 언제든 연장 가능
  - 버튼 레이아웃: [연장하기] [체크아웃] 형태로 그룹화
  
- **UI 개선**
  - 연장하기 버튼: 인디고 계열 색상
  - 체크아웃 버튼: 레드 계열 색상 (기존 유지)
  - 두 버튼을 flex 그룹으로 배치하여 시각적 균형 개선

### 파일 변경

- `src/pages/guesthouse-page.tsx`
  - ExtendStayModal import 추가
  - isExtendModalOpen 상태 관리
  - handleExtendClick에서 모달 열기
  - ExtendStayModal 컴포넌트 추가

- `src/pages/private-room-page.tsx`
  - 헤더에 연장하기 버튼 추가
  - 연장하기 + 체크아웃 버튼 그룹 레이아웃
  - 버튼 색상 및 스타일 조정

## Test plan

### 게스트하우스 페이지
- [ ] 연장하기 버튼 클릭 시 ExtendStayModal 열림 확인
- [ ] 모달에서 현재 체크아웃 시간 표시 확인
- [ ] 모달에서 연장 성공 시 체크아웃 시간 업데이트 확인
- [ ] 모달 닫기 동작 확인

### 개인 숙소 페이지
- [ ] 헤더에 연장하기 버튼 상시 노출 확인
- [ ] 연장하기 버튼 클릭 시 ExtendStayModal 열림 확인
- [ ] 임박 알림 배너의 연장하기 버튼과 헤더 연장하기 버튼 모두 작동 확인
- [ ] 헤더 버튼 레이아웃 (연장하기 + 체크아웃) 확인
- [ ] 버튼 색상 및 hover 효과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)