### PR TITLE
fix: 게스트하우스 및 개인 숙소 체크아웃 리다이렉트 로직 개선

### DIFF
--- a/src/pages/guesthouse-page.tsx
+++ b/src/pages/guesthouse-page.tsx
@@ -35,10 +35,11 @@ export default function GuesthousePage() {
 
   // 체류 정보가 없으면 홈으로 리다이렉트
   useEffect(() => {
-    if (isRoomStayError) {
+    // 에러가 발생했거나, 로딩이 끝났는데 데이터가 없는 경우 홈으로 이동
+    if (isRoomStayError || (!isRoomStayLoading && !roomStay)) {
       navigate(ROUTES.HOME, { replace: true });
     }
-  }, [isRoomStayError, navigate]);
+  }, [isRoomStayError, isRoomStayLoading, roomStay, navigate]);
 
   // 연장하기 버튼 핸들러
   const handleExtendClick = () => {


### PR DESCRIPTION
## Summary
게스트하우스와 개인 숙소 페이지에서 체크아웃 및 리다이렉트 로직을 개선하여 사용자 경험을 향상시켰습니다.

## 변경 사항

### 게스트하우스 페이지 (`guesthouse-page.tsx`)
- 에러가 발생했거나 로딩이 끝났는데 체류 정보가 없는 경우 홈으로 리다이렉트
- 기존: 에러가 발생했을 때만 리다이렉트
- 개선: 로딩 완료 후 데이터가 없을 때도 리다이렉트 (더 안전한 처리)

### 개인 숙소 페이지 (`private-room-page.tsx`)
- 수동 체크아웃 중이거나 성공했을 때 자동 리다이렉트 방지
- 체크아웃 성공 후 터미널로 직접 이동하도록 변경
- `isCheckoutSuccess` 상태를 추가하여 체크아웃 성공 후 자동 리다이렉트와 충돌 방지

## 해결된 문제
- 수동 체크아웃 시 자동 리다이렉트와 충돌하는 문제 해결
- 체류 정보가 없을 때 예상치 못한 동작 방지
- 체크아웃 후 명확한 화면 전환 (터미널로 이동)

## Test Plan
- [ ] 게스트하우스 페이지에서 체류 정보가 없을 때 홈으로 정상 리다이렉트
- [ ] 개인 숙소에서 수동 체크아웃 시 터미널로 정상 이동
- [ ] 체크아웃 중 자동 리다이렉트가 발생하지 않는지 확인
- [ ] 퇴실 시간 만료 시 자동 체크아웃 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)