### PR TITLE
fix: API 에러 파싱 로직 개선 및 포인트 부족 에러 처리 추가

### DIFF
--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -19,6 +19,7 @@ export const ErrorCode = {
   DUPLICATED_REWARD: "DUPLICATED_REWARD",
   DUPLICATED_USER: "DUPLICATED_USER",
   PROFILE_INCOMPLETE: "PROFILE_INCOMPLETE",
+  INSUFFICIENT_POINTS: "INSUFFICIENT_POINTS",
 } as const;
 
 /**
@@ -47,9 +48,30 @@ export class B0ApiError extends Error {
  * @returns B0ApiError 인스턴스
  */
 export function parseApiError(error: unknown): B0ApiError {
-  if (error instanceof AxiosError && error.response?.data?.error) {
-    const apiError = error.response.data.error as ApiError;
-    return new B0ApiError(apiError.code, apiError.message, error.response.status);
+  if (error instanceof AxiosError) {
+    // Case 1: Standard B0 API Error ({ error: { code, message } })
+    if (error.response?.data?.error) {
+      const apiError = error.response.data.error as ApiError;
+      return new B0ApiError(apiError.code, apiError.message, error.response.status ?? 500);
+    }
+
+    // Case 2: FastAPI detail style ({ detail: string })
+    if (error.response?.data?.detail) {
+      const detail = error.response.data.detail;
+
+      if (detail === "Insufficient points") {
+        return new B0ApiError(
+          ErrorCode.INSUFFICIENT_POINTS,
+          "포인트가 부족합니다.",
+          error.response.status ?? 400
+        );
+      }
+
+      // Fallback for other detail messages
+      const message = typeof detail === "string" ? detail : "요청 처리 중 오류가 발생했습니다.";
+      return new B0ApiError("BAD_REQUEST", message, error.response.status ?? 400);
+    }
   }
+
   return new B0ApiError("UNKNOWN", "알 수 없는 오류가 발생했습니다.", 500);
 }


### PR DESCRIPTION
## Summary
API 에러 파싱 로직을 개선하여 다양한 에러 응답 형식을 처리하고, 포인트 부족 에러에 대한 한국어 메시지를 추가했습니다.

## 변경 사항

### API 에러 파싱 로직 개선 (`api-errors.ts`)
- **FastAPI detail 스타일 에러 응답 처리 추가**
  - 기존: `{ error: { code, message } }` 형식만 처리
  - 추가: `{ detail: string }` 형식도 처리 (FastAPI 표준)

- **INSUFFICIENT_POINTS 에러 코드 추가**
  - `"Insufficient points"` 에러를 감지하여 한국어 메시지로 변환
  - 에러 코드: `INSUFFICIENT_POINTS`
  - 메시지: `"포인트가 부족합니다."`

- **기타 detail 메시지 fallback 처리**
  - 알 수 없는 detail 메시지는 `BAD_REQUEST` 코드로 처리
  - detail이 문자열이 아닌 경우 기본 메시지 사용

### 개선 효과
- FastAPI 백엔드의 다양한 에러 응답 형식을 안정적으로 처리
- 포인트 부족 시 사용자에게 명확한 한국어 메시지 제공
- 예상치 못한 에러 형식에 대한 방어 코드 추가

## Test Plan
- [ ] 포인트 부족 시 에러 메시지 확인 (일기 작성, 문답지 작성 등)
- [ ] FastAPI detail 에러 응답이 정상적으로 파싱되는지 확인
- [ ] 기존 B0 API 에러 형식이 여전히 정상 작동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)