### PR TITLE
fix: 1:1 대화 거절 기능 제거 및 에러 핸들링 개선

### DIFF
--- a/src/api/dm.ts
+++ b/src/api/dm.ts
@@ -21,12 +21,6 @@ export async function acceptDM(dmRoomId: string): Promise<DirectMessageRoom> {
   return response.data;
 }
 
-/** 1:1 대화 거절 */
-export async function rejectDM(dmRoomId: string): Promise<DirectMessageRoom> {
-  const response = await apiClient.post<DirectMessageRoom>(`${BASE_URL}/requests/${dmRoomId}/reject`);
-  return response.data;
-}
-
 // ============================================================================
 // Query (Fetch)
 // ============================================================================

--- a/src/hooks/queries/use-dm.ts
+++ b/src/hooks/queries/use-dm.ts
@@ -1,5 +1,5 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient, type InfiniteData } from "@tanstack/react-query";
-import { acceptDM, getDMMessages, getMyDMRooms, rejectDM, requestDM } from "@/api/dm";
+import { acceptDM, getDMMessages, getMyDMRooms, requestDM } from "@/api/dm";
 import { queryKeys } from "@/lib/query-client";
 import type { B0ApiError } from "@/lib/api-errors";
 import { toast } from "sonner";
@@ -64,6 +64,7 @@ export function useRequestDM() {
   });
 }
 
+// remove useRejectDM
 export function useAcceptDM() {
   const queryClient = useQueryClient();
 
@@ -75,22 +76,13 @@ export function useAcceptDM() {
       return data;
     },
     onError: (error: B0ApiError) => {
-      toast.error(error.message || "수락 실패");
-    },
-  });
-}
-
-export function useRejectDM() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: rejectDM,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.dm.all });
-      toast.success("대화 신청을 거절했습니다.");
-    },
-    onError: (error: B0ApiError) => {
-      toast.error(error.message || "거절 실패");
+      if (error.code === "NOT_FOUND_DM_ROOM") {
+        toast.error("존재하지 않거나 만료된 대화방입니다.");
+      } else if (error.code === "FORBIDDEN_DM_ROOM_ACCESS") {
+        toast.error("접근 권한이 없습니다.");
+      } else {
+        toast.error(error.message || "수락 실패");
+      }
     },
   });
 }


### PR DESCRIPTION
## Summary
1:1 대화(DM) 시스템에서 거절 기능을 제거하여 서버 에러를 방지하고, 사용자 경험을 단순화했습니다.

## 변경 사항

### API 레이어 (`src/api/dm.ts`)
- `rejectDM` 함수 제거
- 거절 관련 API 엔드포인트 호출 코드 삭제

### 훅 레이어 (`src/hooks/queries/use-dm.ts`)
- `useRejectDM` 훅 제거
- `useAcceptDM` 에러 핸들링 개선
  - `NOT_FOUND_DM_ROOM`: "존재하지 않거나 만료된 대화방입니다."
  - `FORBIDDEN_DM_ROOM_ACCESS`: "접근 권한이 없습니다."
  - 기타 에러: 기본 에러 메시지 표시

### UI 컴포넌트 (`src/components/lounge/TravelerItem.tsx`)
- 대화 신청 받은 경우 "거절" 버튼 제거
- "수락" 버튼만 표시
- 수락 성공 시 DM 방으로 자동 이동 (`navigate`)
- 버튼 disabled 상태 간소화 (`isRejecting` 제거)

## 해결된 문제

### 서버 에러 방지 (#69)
- **Issue**: 대화 재신청 시 서버 에러(500) 발생
- **Root Cause**: 거절 기능의 복잡한 상태 관리 및 엣지 케이스
- **Fix**: 거절 기능 자체를 제거하여 에러 가능성 차단

### UX 개선
- 의사결정 단순화: 수락만 가능하도록 변경
- 원하지 않는 대화는 무시하면 자동으로 처리되는 방식
- 수락 시 즉시 대화방으로 이동하여 자연스러운 플로우

## 기술적 개선

### 에러 핸들링 강화
```typescript
// Before: 단순 에러 메시지
onError: (error: B0ApiError) => {
  toast.error(error.message || "수락 실패");
}

// After: 에러 코드별 상세 메시지
onError: (error: B0ApiError) => {
  if (error.code === "NOT_FOUND_DM_ROOM") {
    toast.error("존재하지 않거나 만료된 대화방입니다.");
  } else if (error.code === "FORBIDDEN_DM_ROOM_ACCESS") {
    toast.error("접근 권한이 없습니다.");
  } else {
    toast.error(error.message || "수락 실패");
  }
}
```

### 수락 후 자동 이동
```typescript
// 수락 버튼 클릭 시
onClick={() => {
  acceptDM(dmRoomId, {
    onSuccess: () => {
      navigate(`/chat/${dmRoomId}`);
    },
  });
}}
```

## UI 변경 사항

### Before (거절 버튼 있음)
```
[수락] [거절]
```

### After (수락 버튼만)
```
[수락]
```

## 관련 Issue
- #69 - 대화 재신청 시 500 에러 핸들링

## 영향 범위
- 라운지 페이지에서 대화 신청 받은 경우의 UI
- 거절 관련 API 호출 및 상태 관리 로직
- 기존에 거절된 대화방의 상태는 유지 (데이터베이스 영향 없음)

## Test Plan
- [ ] 라운지에서 대화 신청 받은 경우 "수락" 버튼만 표시되는지 확인
- [ ] 수락 버튼 클릭 시 DM 방으로 정상 이동하는지 확인
- [ ] 존재하지 않는 대화방 수락 시 적절한 에러 메시지 표시 확인
- [ ] 권한 없는 대화방 수락 시 적절한 에러 메시지 표시 확인
- [ ] 대화 신청 재신청 시 서버 에러가 발생하지 않는지 확인

## 참고
이 변경은 release_roadmap.md의 "에러 핸들링 (500 Error)" 항목에 해당하는 배포 전 필수 작업입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)