### PR TITLE
feat: 포인트 부족 모달 및 무료 충전 요청 버튼 추가

### DIFF
--- a/src/components/booking/purchase-button.tsx
+++ b/src/components/booking/purchase-button.tsx
@@ -4,34 +4,44 @@ interface PurchaseButtonProps {
   hasEnoughPoints: boolean;
   isPending?: boolean;
   onPurchase: () => void;
+  /** 포인트 부족 시 호출되는 콜백 (모달 열기 용도) */
+  onInsufficientPoints?: () => void;
 }
 
 /**
  * 비행선 구매 버튼 컴포넌트
  *
- * 포인트 부족 또는 요청 중일 때 비활성화
+ * 포인트 부족 시 클릭하면 모달을 열고, 충분하면 구매 진행
  */
-export function PurchaseButton({ hasEnoughPoints, isPending = false, onPurchase }: PurchaseButtonProps) {
-  const isDisabled = !hasEnoughPoints || isPending;
+export function PurchaseButton({
+  hasEnoughPoints,
+  isPending = false,
+  onPurchase,
+  onInsufficientPoints,
+}: PurchaseButtonProps) {
+  const handleClick = () => {
+    if (!hasEnoughPoints) {
+      onInsufficientPoints?.();
+      return;
+    }
+    onPurchase();
+  };
 
   return (
     <div className="mt-auto">
-      {!hasEnoughPoints && (
-        <div className="mb-4 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-300">
-          포인트가 부족합니다. 일기를 쓰거나 대화에 참여해보세요.
-        </div>
-      )}
       <button
-        disabled={isDisabled}
-        onClick={onPurchase}
+        disabled={isPending}
+        onClick={handleClick}
         className={cn(
           "w-full rounded-lg py-4 text-base font-semibold transition-colors",
-          isDisabled
-            ? "cursor-not-allowed bg-zinc-700 text-zinc-400"
-            : "bg-b0-purple hover:bg-b0-light-purple text-white"
+          !hasEnoughPoints
+            ? "border border-red-500/30 bg-red-500/20 text-red-300"
+            : isPending
+              ? "cursor-not-allowed bg-zinc-700 text-zinc-400"
+              : "bg-b0-purple hover:bg-b0-light-purple text-white"
         )}
       >
-        {isPending ? "처리 중..." : "🎫 비행선 탑승하기"}
+        {isPending ? "처리 중..." : !hasEnoughPoints ? "포인트 부족" : "비행선 탑승하기"}
       </button>
     </div>
   );

--- a/src/components/insufficient-points-modal.tsx
+++ b/src/components/insufficient-points-modal.tsx
@@ -1,0 +1,87 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { toast } from "sonner";
+import { trackEvent } from "@/lib/analytics.ts";
+
+interface InsufficientPointsModalProps {
+  /** 모달 열림 상태 */
+  open: boolean;
+  /** 모달 닫기 콜백 */
+  onOpenChange: (open: boolean) => void;
+  /** 현재 사용자 보유 포인트 */
+  currentBalance: number;
+  /** 모달이 호출된 컨텍스트 (GA 이벤트용) */
+  source: "ticket_booking" | "extend_stay";
+}
+
+/**
+ * 포인트 부족 시 표시되는 모달 컴포넌트
+ *
+ * - 현재 보유 포인트 표시
+ * - 포인트 획득 방법 안내
+ * - '포인트 무료 충전 요청' 버튼 (Fake Door Test)
+ */
+export function InsufficientPointsModal({ open, onOpenChange, currentBalance, source }: InsufficientPointsModalProps) {
+  const handleRequestFreeCharge = () => {
+    // GA4 이벤트 전송
+    trackEvent("demand_verification_click", {
+      feature_name: "free_point_charge",
+      current_balance: currentBalance,
+      source,
+    });
+
+    // Toast 메시지 표시
+    toast.info("포인트 무료 충전 기능을 준비 중입니다. 조금만 기다려주세요!");
+
+    // 모달 닫기
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-b0-deep-navy border-zinc-800 sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-white">포인트가 부족해요</DialogTitle>
+          <DialogDescription className="text-zinc-400">
+            일기를 쓰거나 대화에 참여하면 포인트를 얻을 수 있어요.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="py-4">
+          {/* 현재 포인트 표시 */}
+          <div className="mb-4 rounded-lg border border-zinc-700 bg-zinc-800/50 p-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-zinc-400">현재 보유 포인트</span>
+              <span className="text-lg font-bold text-white">{currentBalance}P</span>
+            </div>
+          </div>
+
+          {/* 포인트 획득 방법 안내 */}
+          <div className="space-y-2 text-sm text-zinc-400">
+            <p>일기 작성: 50P</p>
+            <p>문답지 작성: 50P</p>
+          </div>
+        </div>
+
+        <DialogFooter className="flex flex-col gap-3 sm:flex-col">
+          {/* 포인트 무료 충전 요청 버튼 (Fake Door) */}
+          <Button onClick={handleRequestFreeCharge} className="bg-b0-purple hover:bg-b0-light-purple w-full">
+            포인트 무료 충전 요청
+          </Button>
+
+          {/* 닫기 버튼 */}
+          <Button variant="outline" onClick={() => onOpenChange(false)} className="w-full border-zinc-700">
+            닫기
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/ticket-booking-page.tsx
+++ b/src/pages/ticket-booking-page.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
-import { useLocation, useNavigate, useParams } from "react-router";
-import { toast } from "sonner";
 import { CityInfo } from "@/components/booking/city-info.tsx";
 import { AirshipSelector } from "@/components/booking/airship-selector.tsx";
 import { PaymentSummary } from "@/components/booking/payment-summary.tsx";
 import { PurchaseButton } from "@/components/booking/purchase-button.tsx";
+import { InsufficientPointsModal } from "@/components/insufficient-points-modal.tsx";
+import { useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router";
+import { toast } from "sonner";
 import { useMe } from "@/hooks/queries/use-me.ts";
 import { useCity } from "@/hooks/queries/use-city.ts";
 import { useAirships } from "@/hooks/queries/use-airships.ts";
@@ -15,12 +16,13 @@ import type { City } from "@/types.ts";
 import { trackButtonClick, trackEvent } from "@/lib/analytics.ts";
 
 export default function TicketBookingPage() {
+  const [selectedAirshipId, setSelectedAirshipId] = useState<string | null>(null);
+  const [isInsufficientModalOpen, setIsInsufficientModalOpen] = useState(false);
+
   const { cityId } = useParams<{ cityId: string }>();
   const location = useLocation();
   const navigate = useNavigate();
   const cityFromState = location.state?.city as City | undefined;
-
-  const [selectedAirshipId, setSelectedAirshipId] = useState<string | null>(null);
 
   const { data: user } = useMe();
   const { data: airshipsData, isLoading: isAirshipsLoading } = useAirships();
@@ -94,7 +96,19 @@ export default function TicketBookingPage() {
         remainingPoints={remainingPoints}
         hasEnoughPoints={hasEnoughPoints}
       />
-      <PurchaseButton hasEnoughPoints={hasEnoughPoints} isPending={isPending} onPurchase={handlePurchase} />
+      <PurchaseButton
+        hasEnoughPoints={hasEnoughPoints}
+        isPending={isPending}
+        onPurchase={handlePurchase}
+        onInsufficientPoints={() => setIsInsufficientModalOpen(true)}
+      />
+
+      <InsufficientPointsModal
+        open={isInsufficientModalOpen}
+        onOpenChange={setIsInsufficientModalOpen}
+        currentBalance={user?.current_points ?? 0}
+        source="ticket_booking"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 포인트 부족 시 표시되는 새로운 `InsufficientPointsModal` 컴포넌트 추가
- '포인트 무료 충전 요청' 버튼을 통한 Fake Door Test 구현
- 버튼 클릭 시 GA4 이벤트(`demand_verification_click`) 전송으로 수요 검증

## Changes
| 파일 | 변경 내용 |
|-----|---------|
| `src/components/insufficient-points-modal.tsx` | 신규 생성 - 포인트 부족 모달 |
| `src/components/booking/purchase-button.tsx` | 포인트 부족 시 모달 열기 콜백 추가 |
| `src/pages/ticket-booking-page.tsx` | 모달 상태 관리 및 렌더링 |
| `src/components/ExtendStayModal.tsx` | 포인트 부족 에러 시 모달 연동 |

## GA4 Event
```typescript
trackEvent("demand_verification_click", {
  feature_name: "free_point_charge",
  current_balance: number,
  source: "ticket_booking" | "extend_stay"
});
```

## Test plan
- [ ] 포인트 부족 상태에서 티켓 예매 → "포인트 부족" 버튼 클릭 → 모달 표시
- [ ] 모달에서 "포인트 무료 충전 요청" 버튼 클릭 → Toast 표시
- [ ] GA4 이벤트 전송 확인 (DevTools > Network)
- [ ] 체류 연장 시 포인트 부족 에러 → 모달 표시

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)