### PR TITLE
feat: 일일 로그인 보상 기능 구현

### DIFF
--- a/src/api/rewards.ts
+++ b/src/api/rewards.ts
@@ -1,0 +1,17 @@
+/**
+ * 백엔드 보상 API 함수 모음
+ */
+import type { DailyLoginReward, DataResponse } from "@/types.ts";
+import apiClient from "@/lib/api-client.ts";
+
+/**
+ * 일일 로그인 보상을 수령합니다
+ *
+ * 한국 시간 기준 자정마다 초기화되며, 하루에 한 번만 보상을 받을 수 있습니다.
+ * - 첫 요청 (같은 날): 100P 지급, claimed=true
+ * - 이후 요청 (같은 날): 기존 기록 반환, claimed=false
+ */
+export async function claimDailyLoginReward(): Promise<DailyLoginReward> {
+  const { data } = await apiClient.post<DataResponse<DailyLoginReward>>("/rewards/daily-login/claim");
+  return data.data;
+}

--- a/src/components/guards/daily-reward-guard.tsx
+++ b/src/components/guards/daily-reward-guard.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from "react";
+import { Outlet } from "react-router";
+import { toast } from "sonner";
+import { useClaimDailyLoginReward } from "@/hooks/mutations/use-claim-daily-login-reward.ts";
+import type { DailyLoginReward } from "@/types.ts";
+
+/**
+ * 일일 로그인 보상을 자동으로 확인하고 지급하는 가드 컴포넌트
+ *
+ * AuthGuard 내부에 배치되어 인증된 사용자가 앱에 진입할 때
+ * 자동으로 일일 보상을 확인하고, 새로운 보상이 있으면 토스트로 알림
+ */
+export default function DailyRewardGuard() {
+  const hasClaimedRef = useRef(false);
+  const { mutate: claimDailyLoginReward } = useClaimDailyLoginReward({
+    onSuccess: (data: DailyLoginReward) => {
+      if (data.claimed) {
+        toast.success(`${data.amount}P 출석 보상을 받았어요!`);
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (!hasClaimedRef.current) {
+      hasClaimedRef.current = true;
+      claimDailyLoginReward();
+    }
+  }, [claimDailyLoginReward]);
+
+  return <Outlet />;
+}

--- a/src/hooks/mutations/use-claim-daily-login-reward.ts
+++ b/src/hooks/mutations/use-claim-daily-login-reward.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { claimDailyLoginReward } from "@/api/rewards.ts";
+import type { DailyLoginReward, UseMutationCallback } from "@/types.ts";
+import { queryKeys } from "@/lib/query-client.ts";
+import type { B0ApiError } from "@/lib/api-errors.ts";
+import { logger } from "@/lib/logger.ts";
+
+/**
+ * 일일 로그인 보상 수령 mutation 훅
+ *
+ * AuthGuard 내 DailyRewardGuard에서 자동 호출되어 일일 보상을 수령
+ * 보상 수령 성공 시 사용자 정보 캐시를 무효화하여 포인트 갱신
+ */
+export function useClaimDailyLoginReward(callback?: UseMutationCallback<DailyLoginReward, B0ApiError>) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: claimDailyLoginReward,
+    onSuccess: async (data: DailyLoginReward) => {
+      // 새로 보상이 지급된 경우에만 사용자 정보 캐시 무효화
+      if (data.claimed) {
+        await queryClient.invalidateQueries({ queryKey: queryKeys.me.all });
+      }
+      callback?.onSuccess?.(data);
+    },
+    onError: (error: B0ApiError) => {
+      logger.error(error);
+      callback?.onError?.(error);
+    },
+  });
+}

--- a/src/root-route.tsx
+++ b/src/root-route.tsx
@@ -13,6 +13,7 @@ import MainLayout from "@/components/layout/main-layout.tsx";
 import OnboardingGuard from "@/components/guards/onboarding-guard.tsx";
 import GuestGuard from "@/components/guards/guest-guard.tsx";
 import AuthGuard from "@/components/guards/auth-guard.tsx";
+import DailyRewardGuard from "@/components/guards/daily-reward-guard.tsx";
 import TravelStatusGuard from "@/components/guards/travel-status-guard.tsx";
 import AuthPage from "@/pages/auth-page.tsx";
 import EmailVerificationPage from "@/pages/email-verification-page.tsx";
@@ -72,94 +73,99 @@ export const router = createBrowserRouter([
           {
             element: <AuthGuard />,
             children: [
-              // TravelStatusGuard 밖: 프로필 설정, 설정
               {
-                path: ROUTES.PROFILE_COMPLETION,
-                element: <ProfileCompletionPage />,
-                handle: { title: "프로필 설정", isRoot: false },
-              },
-              {
-                path: ROUTES.SETTINGS,
-                element: <SettingsPage />,
-                handle: { title: "설정", isRoot: false },
-              },
-              {
-                path: ROUTES.MYPAGE,
-                element: <MyPage />,
-                handle: { title: "마이페이지", isRoot: false },
-              },
-              {
-                path: ROUTES.MYPAGE_DIARIES,
-                element: <MyDiariesPage />,
-                handle: { title: "나의 일기", isRoot: false },
-              },
-              {
-                path: ROUTES.MYPAGE_QUESTIONNAIRES,
-                element: <MyQuestionnairesPage />,
-                handle: { title: "나의 문답지", isRoot: false },
-              },
-              // TravelStatusGuard 안: 여행 상태에 따라 리다이렉트
-              {
-                element: <TravelStatusGuard />,
+                element: <DailyRewardGuard />,
                 children: [
+                  // TravelStatusGuard 밖: 프로필 설정, 설정
                   {
-                    path: ROUTES.HOME,
-                    element: <IndexPage />,
-                    handle: { title: "홈", isRoot: true },
+                    path: ROUTES.PROFILE_COMPLETION,
+                    element: <ProfileCompletionPage />,
+                    handle: { title: "프로필 설정", isRoot: false },
                   },
                   {
-                    path: ROUTES.TERMINAL,
-                    element: <TerminalPage />,
-                    handle: { title: "B0 터미널", isRoot: true },
+                    path: ROUTES.SETTINGS,
+                    element: <SettingsPage />,
+                    handle: { title: "설정", isRoot: false },
                   },
                   {
-                    path: ROUTES.TICKET_BOOKING,
-                    element: <TicketBookingPage />,
-                    handle: { title: "비행선 예매", isRoot: false },
+                    path: ROUTES.MYPAGE,
+                    element: <MyPage />,
+                    handle: { title: "마이페이지", isRoot: false },
                   },
                   {
-                    path: ROUTES.BOARDING,
-                    element: <BoardingPage />,
-                    handle: { title: "탑승중", isRoot: true },
+                    path: ROUTES.MYPAGE_DIARIES,
+                    element: <MyDiariesPage />,
+                    handle: { title: "나의 일기", isRoot: false },
                   },
                   {
-                    path: ROUTES.LIVING_ROOM,
-                    element: <LivingRoomPage />,
-                    handle: { title: "사랑방", isRoot: false },
+                    path: ROUTES.MYPAGE_QUESTIONNAIRES,
+                    element: <MyQuestionnairesPage />,
+                    handle: { title: "나의 문답지", isRoot: false },
                   },
+                  // TravelStatusGuard 안: 여행 상태에 따라 리다이렉트
                   {
-                    path: ROUTES.LOUNGE,
-                    element: <LoungePage />,
-                    handle: { title: "라운지", isRoot: false },
-                  },
-                  {
-                    path: ROUTES.PRIVATE_ROOM,
-                    element: <PrivateRoomPage />,
-                    handle: { title: "개인 숙소", isRoot: false },
-                  },
-                  {
-                    path: ROUTES.DIARY,
-                    element: <DiaryPage />,
-                    handle: { title: "일기장", isRoot: false },
-                  },
-                  {
-                    path: ROUTES.QUESTIONNAIRE,
-                    element: <QuestionnairePage />,
-                    handle: { title: "문답지", isRoot: false },
-                  },
-                  {
-                    path: ROUTES.GUESTHOUSE,
-                    element: <GuesthousePage />,
-                    handle: { title: "", isRoot: true },
-                  },
-                  {
-                    path: ROUTES.CHAT,
-                    element: <DMRoomPage />,
-                    handle: { title: "", isRoot: true },
-                  },
-                  {
-                    path: "*",
-                    element: <Navigate to={ROUTES.HOME} />,
+                    element: <TravelStatusGuard />,
+                    children: [
+                      {
+                        path: ROUTES.HOME,
+                        element: <IndexPage />,
+                        handle: { title: "홈", isRoot: true },
+                      },
+                      {
+                        path: ROUTES.TERMINAL,
+                        element: <TerminalPage />,
+                        handle: { title: "B0 터미널", isRoot: true },
+                      },
+                      {
+                        path: ROUTES.TICKET_BOOKING,
+                        element: <TicketBookingPage />,
+                        handle: { title: "비행선 예매", isRoot: false },
+                      },
+                      {
+                        path: ROUTES.BOARDING,
+                        element: <BoardingPage />,
+                        handle: { title: "탑승중", isRoot: true },
+                      },
+                      {
+                        path: ROUTES.LIVING_ROOM,
+                        element: <LivingRoomPage />,
+                        handle: { title: "사랑방", isRoot: false },
+                      },
+                      {
+                        path: ROUTES.LOUNGE,
+                        element: <LoungePage />,
+                        handle: { title: "라운지", isRoot: false },
+                      },
+                      {
+                        path: ROUTES.PRIVATE_ROOM,
+                        element: <PrivateRoomPage />,
+                        handle: { title: "개인 숙소", isRoot: false },
+                      },
+                      {
+                        path: ROUTES.DIARY,
+                        element: <DiaryPage />,
+                        handle: { title: "일기장", isRoot: false },
+                      },
+                      {
+                        path: ROUTES.QUESTIONNAIRE,
+                        element: <QuestionnairePage />,
+                        handle: { title: "문답지", isRoot: false },
+                      },
+                      {
+                        path: ROUTES.GUESTHOUSE,
+                        element: <GuesthousePage />,
+                        handle: { title: "", isRoot: true },
+                      },
+                      {
+                        path: ROUTES.CHAT,
+                        element: <DMRoomPage />,
+                        handle: { title: "", isRoot: true },
+                      },
+                      {
+                        path: "*",
+                        element: <Navigate to={ROUTES.HOME} />,
+                      },
+                    ],
                   },
                 ],
               },

--- a/src/types.ts
+++ b/src/types.ts
@@ -384,3 +384,21 @@ export interface DirectMessagePage {
   messages: DirectMessage[];
   nextCursor: string | undefined;
 }
+
+// ============================================================================
+// 보상(Reward) 관련 타입
+// ============================================================================
+
+/** 일일 로그인 보상 정보 */
+export interface DailyLoginReward {
+  reward_id: string;
+  user_id: string;
+  reward_type: "daily_login";
+  /** 지급 포인트 */
+  amount: number;
+  /** 기준 날짜 (YYYY-MM-DD) */
+  reference_date: string;
+  /** 새로 지급 여부 (true: 새로 지급됨, false: 이미 받음) */
+  claimed: boolean;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
- 일일 로그인 시 100P 출석 보상 자동 지급
- `DailyRewardGuard` 컴포넌트를 통해 AuthGuard 레벨에서 보상 체크
- 새로운 보상 지급 시 토스트 알림 표시
- 백엔드 API를 통한 중복 지급 방지 (`claimed: false` 시 토스트 미표시)

## Changes
- `src/api/rewards.ts` - 보상 API 함수 추가
- `src/hooks/mutations/use-claim-daily-login-reward.ts` - Mutation 훅 추가
- `src/components/guards/daily-reward-guard.tsx` - 일일 보상 가드 컴포넌트 추가
- `src/root-route.tsx` - DailyRewardGuard를 AuthGuard 자식으로 추가
- `src/types.ts` - `DailyLoginReward` 타입 추가

## Test plan
- [x] 첫 로그인 시 100P 출석 보상 토스트 표시 확인
- [x] 같은 날 재방문 시 토스트 미표시 확인 (중복 지급 방지)
- [x] API 응답 `claimed: true/false` 정상 동작 확인

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)