### PR TITLE
feat: 터미널 페이지에 홈화면 추가 안내 모달 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,15 +21,26 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-icon-180x180.png" />
     <link rel="manifest" href="/manifest.json" />
 
+    <!-- iOS Safari 홈화면 추가 지원 -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="B0" />
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content" />
 
     <title>B0 - 지하 0층</title>
-    <meta name="description" content="지하 0층에서 출발하는 비행선을 타고 가상 세계를 여행하며 힐링과 자기성찰을 경험하세요." />
+    <meta
+      name="description"
+      content="지하 0층에서 출발하는 비행선을 타고 가상 세계를 여행하며 힐링과 자기성찰을 경험하세요."
+    />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="B0 - 지하 0층" />
-    <meta property="og:description" content="지하 0층에서 출발하는 비행선을 타고 가상 세계를 여행하며 힐링과 자기성찰을 경험하세요." />
+    <meta
+      property="og:description"
+      content="지하 0층에서 출발하는 비행선을 타고 가상 세계를 여행하며 힐링과 자기성찰을 경험하세요."
+    />
     <meta property="og:image" content="https://app.basementzero.cloud/og-image.jpg" />
     <meta property="og:url" content="https://app.basementzero.cloud" />
     <meta property="og:site_name" content="B0" />
@@ -38,7 +49,10 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="B0 - 지하 0층" />
-    <meta name="twitter:description" content="지하 0층에서 출발하는 비행선을 타고 가상 세계를 여행하며 힐링과 자기성찰을 경험하세요." />
+    <meta
+      name="twitter:description"
+      content="지하 0층에서 출발하는 비행선을 타고 가상 세계를 여행하며 힐링과 자기성찰을 경험하세요."
+    />
     <meta name="twitter:image" content="https://app.basementzero.cloud/og-image.jpg" />
     <link
       rel="stylesheet"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,14 +1,16 @@
 {
-  "name": "B0",
+  "name": "B0 - 지하 0층",
+  "short_name": "B0",
+  "description": "지하 0층에서 출발하는 비행선을 타고 가상 세계를 여행하며 힐링과 자기성찰을 경험하세요.",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#0f0f23",
+  "background_color": "#0f0f23",
   "icons": [
     {
-      "src": "\/android-icon-192x192.png",
+      "src": "/android-icon-192x192.png",
       "sizes": "192x192",
-      "type": "image\/png",
-      "density": "4.0"
+      "type": "image/png"
     }
-  ],
-  "theme_color": "#ffffff",
-  "background_color": "#0f0f23",
-  "display": "standalone"
+  ]
 }

--- a/src/components/terminal/add-to-home-screen-modal.tsx
+++ b/src/components/terminal/add-to-home-screen-modal.tsx
@@ -1,0 +1,126 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { MoreVertical, Plus, Share } from "lucide-react";
+import type { BrowserType } from "@/lib/device.ts";
+
+interface AddToHomeScreenModalProps {
+  /** 모달 열림 상태 */
+  open: boolean;
+  /** 모달 상태 변경 콜백 */
+  onOpenChange: (open: boolean) => void;
+  /** 브라우저 유형 (iOS Safari 또는 Android Chrome) */
+  browserType: BrowserType;
+  /** "다시 보지 않기" 버튼 클릭 콜백 */
+  onDismissForever: () => void;
+}
+
+/**
+ * 홈화면 추가 안내 모달 컴포넌트
+ *
+ * - iOS Safari: "공유 버튼 → 홈 화면에 추가" 안내
+ * - Android Chrome: "메뉴 → 홈 화면에 추가" 안내
+ */
+export function AddToHomeScreenModal({ open, onOpenChange, browserType, onDismissForever }: AddToHomeScreenModalProps) {
+  const isIOS = browserType === "ios-safari";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-b0-deep-navy border-zinc-800 sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-white">
+            <Plus className="text-b0-light-purple size-5" />홈 화면에 추가하기
+          </DialogTitle>
+          <DialogDescription className="text-zinc-400">
+            B0를 홈 화면에 추가하면 더 빠르게 접속할 수 있어요.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="py-4">
+          <div className="space-y-4">
+            {isIOS ? (
+              <>
+                {/* iOS Safari 안내 */}
+                <div className="flex items-start gap-3">
+                  <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-zinc-800">
+                    <span className="text-sm font-bold text-white">1</span>
+                  </div>
+                  <div className="flex-1">
+                    <p className="text-sm text-white">
+                      하단의{" "}
+                      <span className="inline-flex items-center gap-1 rounded bg-zinc-800 px-1.5 py-0.5">
+                        <Share className="text-b0-light-purple size-4" />
+                        공유
+                      </span>{" "}
+                      버튼을 탭하세요
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-zinc-800">
+                    <span className="text-sm font-bold text-white">2</span>
+                  </div>
+                  <div className="flex-1">
+                    <p className="text-sm text-white">
+                      <span className="inline-flex items-center gap-1 rounded bg-zinc-800 px-1.5 py-0.5">
+                        <Plus className="text-b0-light-purple size-4" />홈 화면에 추가
+                      </span>
+                      를 선택하세요
+                    </p>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <>
+                {/* Android Chrome 안내 */}
+                <div className="flex items-start gap-3">
+                  <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-zinc-800">
+                    <span className="text-sm font-bold text-white">1</span>
+                  </div>
+                  <div className="flex-1">
+                    <p className="text-sm text-white">
+                      우측 상단의{" "}
+                      <span className="inline-flex items-center gap-1 rounded bg-zinc-800 px-1.5 py-0.5">
+                        <MoreVertical className="text-b0-light-purple size-4" />
+                        메뉴
+                      </span>{" "}
+                      버튼을 탭하세요
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-zinc-800">
+                    <span className="text-sm font-bold text-white">2</span>
+                  </div>
+                  <div className="flex-1">
+                    <p className="text-sm text-white">
+                      <span className="inline-flex items-center gap-1 rounded bg-zinc-800 px-1.5 py-0.5">
+                        <Plus className="text-b0-light-purple size-4" />홈 화면에 추가
+                      </span>
+                      를 선택하세요
+                    </p>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter className="flex flex-col gap-3 sm:flex-col">
+          <Button onClick={() => onOpenChange(false)} className="bg-b0-purple hover:bg-b0-light-purple w-full">
+            확인
+          </Button>
+          <Button variant="ghost" onClick={onDismissForever} className="w-full text-zinc-500 hover:text-zinc-300">
+            다시 보지 않기
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/use-add-to-home-screen.ts
+++ b/src/hooks/use-add-to-home-screen.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from "react";
+import { canShowAddToHomeScreen, detectBrowser, type BrowserType } from "@/lib/device.ts";
+
+const STORAGE_KEY = "b0-add-to-home-dismissed";
+
+interface UseAddToHomeScreenReturn {
+  /** 모달 표시 여부 */
+  isOpen: boolean;
+  /** 현재 브라우저 유형 */
+  browserType: BrowserType;
+  /** 모달 닫기 (일시적) */
+  handleClose: () => void;
+  /** "다시 보지 않기" 처리 */
+  handleDismissForever: () => void;
+}
+
+/**
+ * 홈화면 추가 안내 모달의 표시 여부와 상태를 관리하는 훅
+ *
+ * - 모바일 브라우저(iOS Safari, Android Chrome)에서만 동작
+ * - standalone 모드(홈화면에서 실행)이면 표시하지 않음
+ * - "다시 보지 않기" 선택 시 localStorage에 저장
+ */
+export function useAddToHomeScreen(): UseAddToHomeScreenReturn {
+  const [isOpen, setIsOpen] = useState(false);
+  const [browserType, setBrowserType] = useState<BrowserType>("other");
+
+  useEffect(() => {
+    // 브라우저 유형 감지
+    const browser = detectBrowser();
+    setBrowserType(browser);
+
+    // localStorage에서 "다시 보지 않기" 설정 확인
+    const isDismissed = (() => {
+      try {
+        return localStorage.getItem(STORAGE_KEY) === "true";
+      } catch {
+        // Private browsing 모드에서 localStorage 접근 실패 시
+        return false;
+      }
+    })();
+
+    // 조건 체크: 모바일 브라우저이고, standalone이 아니고, dismissed가 아니면 표시
+    if (canShowAddToHomeScreen() && !isDismissed) {
+      setIsOpen(true);
+    }
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const handleDismissForever = useCallback(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, "true");
+    } catch {
+      // Private browsing 모드에서 localStorage 접근 실패 시 무시
+    }
+    setIsOpen(false);
+  }, []);
+
+  return {
+    isOpen,
+    browserType,
+    handleClose,
+    handleDismissForever,
+  };
+}

--- a/src/lib/device.ts
+++ b/src/lib/device.ts
@@ -1,0 +1,66 @@
+/**
+ * 브라우저 유형
+ */
+export type BrowserType = "ios-safari" | "android-chrome" | "other";
+
+/**
+ * 현재 브라우저 유형을 감지합니다.
+ *
+ * - iOS Safari: iPad, iPhone, iPod에서 Safari 브라우저
+ * - Android Chrome: Android에서 Chrome 브라우저
+ * - other: 그 외 모든 브라우저 (데스크톱, iOS Chrome 등)
+ */
+export function detectBrowser(): BrowserType {
+  if (typeof navigator === "undefined") {
+    return "other";
+  }
+
+  const ua = navigator.userAgent;
+
+  // iOS Safari 감지
+  // - iOS 디바이스인지 확인 (iPad, iPhone, iPod)
+  // - Safari이면서 Chrome이 아닌지 확인 (iOS Chrome은 CriOS로 표시됨)
+  const isIOS = /iPad|iPhone|iPod/.test(ua) && !("MSStream" in window);
+  const isSafari = /Safari/.test(ua) && !/CriOS|Chrome/.test(ua);
+  if (isIOS && isSafari) {
+    return "ios-safari";
+  }
+
+  // Android Chrome 감지
+  const isAndroid = /Android/.test(ua);
+  const isChrome = /Chrome/.test(ua) && !/Edge|Edg/.test(ua);
+  if (isAndroid && isChrome) {
+    return "android-chrome";
+  }
+
+  return "other";
+}
+
+/**
+ * 앱이 standalone 모드(홈화면에서 실행)인지 확인합니다.
+ */
+export function isStandaloneMode(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  // iOS Safari standalone 체크
+  if ("standalone" in window.navigator) {
+    return (window.navigator as Navigator & { standalone: boolean }).standalone === true;
+  }
+
+  // Android Chrome (display-mode: standalone 체크)
+  return window.matchMedia("(display-mode: standalone)").matches;
+}
+
+/**
+ * 모바일 브라우저에서 홈화면 추가가 가능한 환경인지 확인합니다.
+ *
+ * 조건:
+ * - iOS Safari 또는 Android Chrome
+ * - standalone 모드가 아님 (이미 홈화면에서 실행 중이 아님)
+ */
+export function canShowAddToHomeScreen(): boolean {
+  const browser = detectBrowser();
+  return browser !== "other" && !isStandaloneMode();
+}

--- a/src/pages/terminal-page.tsx
+++ b/src/pages/terminal-page.tsx
@@ -3,9 +3,11 @@ import { TerminalTitle } from "@/components/terminal/terminal-title.tsx";
 import { TerminalInfo } from "@/components/terminal/terminal-info.tsx";
 import { CityList } from "@/components/terminal/city-list.tsx";
 import { ComingSoonSection } from "@/components/terminal/coming-soon-section.tsx";
+import { AddToHomeScreenModal } from "@/components/terminal/add-to-home-screen-modal.tsx";
 import { useMe } from "@/hooks/queries/use-me.ts";
 import { useActiveCities } from "@/hooks/queries/use-active-cities.ts";
 import { useAirships } from "@/hooks/queries/use-airships.ts";
+import { useAddToHomeScreen } from "@/hooks/use-add-to-home-screen.ts";
 import type { Airship } from "@/types.ts";
 
 const CITIES_PER_PAGE = 20;
@@ -18,6 +20,7 @@ export default function TerminalPage() {
     isError: isCitiesError,
   } = useActiveCities(0, CITIES_PER_PAGE);
   const { data: airshipListData, isLoading: isAirshipsLoading, isError: isAirshipsError } = useAirships();
+  const { isOpen: isAddToHomeScreenOpen, browserType, handleClose, handleDismissForever } = useAddToHomeScreen();
 
   const airships: Airship[] = airshipListData?.list ?? [];
 
@@ -49,6 +52,14 @@ export default function TerminalPage() {
           <ComingSoonSection />
         </div>
       </div>
+
+      {/* 홈화면 추가 안내 모달 */}
+      <AddToHomeScreenModal
+        open={isAddToHomeScreenOpen}
+        onOpenChange={handleClose}
+        browserType={browserType}
+        onDismissForever={handleDismissForever}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 모바일 사용자가 터미널 페이지 접속 시 홈화면 추가 방법을 안내하는 모달 표시
- iOS Safari: "공유 → 홈 화면에 추가" 안내
- Android Chrome: "메뉴 → 홈 화면에 추가" 안내
- "다시 보지 않기" 선택 시 localStorage에 저장하여 재표시 방지

## Test plan
- [ ] iOS Safari에서 터미널 페이지 접속 → 모달 표시 확인
- [ ] Android Chrome에서 터미널 페이지 접속 → 모달 표시 확인
- [ ] 데스크톱 브라우저 → 모달 미표시 확인
- [ ] "다시 보지 않기" 선택 후 새로고침 → 모달 미표시 확인
- [ ] 홈화면에서 앱 실행 시 → 모달 미표시 확인

Closes #92

🤖 Generated with [Claude Code](https://claude.ai/code)