### PR TITLE
feat: 알림 시스템 구현 (Bell Icon + Notification Sheet)

### DIFF
--- a/src/api/notifications.ts
+++ b/src/api/notifications.ts
@@ -1,0 +1,46 @@
+/**
+ * 알림 API 함수 모음
+ */
+import apiClient from "@/lib/api-client";
+import type { DataResponse, Notification, NotificationListResponse } from "@/types";
+
+/**
+ * 내 알림 목록 조회
+ *
+ * @param params.offset - 목록 시작 위치
+ * @param params.limit - 조회할 개수
+ * @param params.is_read - 읽음 여부 필터 (true: 읽음, false: 안읽음, undefined: 전체)
+ */
+export async function getMyNotifications(params: {
+    offset: number;
+    limit: number;
+    is_read?: boolean;
+}): Promise<NotificationListResponse> {
+    const { data } = await apiClient.get<NotificationListResponse>("/notifications", { params });
+    return data;
+}
+
+/**
+ * 읽지 않은 알림 개수 조회
+ */
+export async function getUnreadCount(): Promise<number> {
+    const { data } = await apiClient.get<DataResponse<number>>("/notifications/unread-count");
+    return data.data;
+}
+
+/**
+ * 알림 읽음 처리
+ *
+ * @param notificationId - 읽음 처리할 알림 ID
+ */
+export async function markNotificationAsRead(notificationId: string): Promise<Notification> {
+    const { data } = await apiClient.patch<DataResponse<Notification>>(`/notifications/${notificationId}/read`);
+    return data.data;
+}
+
+/**
+ * 모든 알림 읽음 처리
+ */
+export async function markAllNotificationsAsRead(): Promise<void> {
+    await apiClient.post("/notifications/read-all");
+}

--- a/src/components/notifications/notification-item.tsx
+++ b/src/components/notifications/notification-item.tsx
@@ -1,0 +1,53 @@
+import { formatDistanceToNow } from "date-fns";
+import { ko } from "date-fns/locale";
+import { Clock, Info, Megaphone, MessageCircle } from "lucide-react";
+import type { Notification } from "@/types";
+import { cn } from "@/lib/utils";
+
+interface NotificationItemProps {
+    notification: Notification;
+    onRead: () => void;
+}
+
+export function NotificationItem({ notification, onRead }: NotificationItemProps) {
+    const getIcon = () => {
+        switch (notification.type) {
+            case "CHECKOUT_REMINDER":
+                return <Clock className="h-5 w-5 text-orange-400" />;
+            case "DM_REQUEST":
+                return <MessageCircle className="h-5 w-5 text-blue-400" />;
+            case "ANNOUNCEMENT":
+                return <Megaphone className="h-5 w-5 text-purple-400" />;
+            case "SYSTEM":
+                return <Info className="h-5 w-5 text-zinc-400" />;
+            default:
+                return <Info className="h-5 w-5 text-zinc-400" />;
+        }
+    };
+
+    return (
+        <div
+            className={cn(
+                "cursor-pointer rounded-lg border p-4 transition-colors hover:bg-zinc-900/50",
+                notification.is_read ? "border-zinc-800 bg-transparent" : "border-indigo-500/50 bg-indigo-500/5"
+            )}
+            onClick={() => !notification.is_read && onRead()}
+        >
+            <div className="flex gap-3">
+                <div className="mt-1">{getIcon()}</div>
+                <div className="flex-1">
+                    <h4 className={cn("text-sm font-semibold", notification.is_read ? "text-zinc-400" : "text-white")}>
+                        {notification.title}
+                    </h4>
+                    <p className="mt-1 text-sm text-zinc-400">{notification.message}</p>
+                    <span className="mt-2 block text-xs text-zinc-500">
+                        {formatDistanceToNow(new Date(notification.created_at), {
+                            addSuffix: true,
+                            locale: ko,
+                        })}
+                    </span>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/notifications/notification-sheet.tsx
+++ b/src/components/notifications/notification-sheet.tsx
@@ -1,0 +1,61 @@
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { useMarkAllAsRead, useMarkNotificationAsRead } from "@/hooks/mutations/use-mark-notification-read";
+import { useNotifications } from "@/hooks/queries/use-notifications";
+import { NotificationItem } from "./notification-item";
+
+interface NotificationSheetProps {
+    open: boolean;
+    onClose: (open: boolean) => void;
+}
+
+export function NotificationSheet({ open, onClose }: NotificationSheetProps) {
+    const { data, isLoading } = useNotifications();
+    const { mutate: markAsRead } = useMarkNotificationAsRead();
+    const { mutate: markAllAsRead } = useMarkAllAsRead();
+
+    const notifications = data?.list ?? [];
+    const hasUnread = notifications.some((n) => !n.is_read);
+
+    return (
+        <Sheet open={open} onOpenChange={onClose}>
+            <SheetContent side="right" className="w-full border-l border-zinc-800 bg-black p-0 sm:max-w-md">
+                <SheetHeader className="border-b border-zinc-800 px-6 py-4">
+                    <div className="flex items-center justify-between">
+                        <SheetTitle className="text-lg font-bold text-white">알림</SheetTitle>
+                        {hasUnread && (
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-auto px-2 text-xs text-zinc-400 hover:text-white"
+                                onClick={() => markAllAsRead()}
+                            >
+                                모두 읽음
+                            </Button>
+                        )}
+                    </div>
+                </SheetHeader>
+
+                <div className="flex h-full flex-col overflow-y-auto px-6 py-4 pb-20">
+                    {isLoading && <div className="py-8 text-center text-sm text-zinc-500">로딩 중...</div>}
+
+                    {!isLoading && notifications.length === 0 && (
+                        <div className="flex flex-1 flex-col items-center justify-center gap-2 py-8 text-center text-zinc-500">
+                            <p>새로운 알림이 없습니다.</p>
+                        </div>
+                    )}
+
+                    <div className="flex flex-col gap-3">
+                        {notifications.map((notification) => (
+                            <NotificationItem
+                                key={notification.notification_id}
+                                notification={notification}
+                                onRead={() => markAsRead(notification.notification_id)}
+                            />
+                        ))}
+                    </div>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/src/components/terminal/terminal-header.tsx
+++ b/src/components/terminal/terminal-header.tsx
@@ -1,6 +1,10 @@
 import { useNavigate } from "react-router";
 import { ROUTES } from "@/lib/routes.ts";
 import logo from "@/assets/images/logo.webp";
+import { useState } from "react";
+import { Bell } from "lucide-react";
+import { useUnreadCount } from "@/hooks/queries/use-notifications";
+import { NotificationSheet } from "@/components/notifications/notification-sheet";
 
 interface TerminalHeaderProps {
   myEmoji: string;
@@ -15,6 +19,9 @@ interface TerminalHeaderProps {
  */
 export function TerminalHeader({ myEmoji, currentPoints }: TerminalHeaderProps) {
   const navigate = useNavigate();
+  const [isNotificationOpen, setIsNotificationOpen] = useState(false);
+  const { data: unreadCount = 0 } = useUnreadCount();
+
 
   return (
     <header className="relative z-10 grid grid-cols-3 items-center border-b-0 bg-transparent py-4">
@@ -27,10 +34,25 @@ export function TerminalHeader({ myEmoji, currentPoints }: TerminalHeaderProps) 
       </button>
       <img src={logo} alt="B0 Logo" className="h-10 justify-self-center" />
       <div className="flex items-center gap-3 justify-self-end">
+        <button
+          onClick={() => setIsNotificationOpen(true)}
+          className="relative rounded-full p-2 transition-colors hover:bg-white/10"
+          aria-label="알림"
+        >
+          <Bell className="h-5 w-5 text-zinc-300" />
+          {unreadCount > 0 && (
+            <span className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white">
+              {unreadCount > 9 ? "9+" : unreadCount}
+            </span>
+          )}
+        </button>
+
         <div className="bg-b0-purple/20 text-b0-light-purple rounded-full px-3 py-1 text-sm font-semibold">
           {currentPoints}P
         </div>
       </div>
+
+      <NotificationSheet open={isNotificationOpen} onClose={setIsNotificationOpen} />
     </header>
   );
 }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,137 @@
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          side === "right" &&
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+          side === "left" &&
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+          side === "top" &&
+            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+          side === "bottom" &&
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <XIcon className="size-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/src/hooks/mutations/use-mark-notification-read.ts
+++ b/src/hooks/mutations/use-mark-notification-read.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { markAllNotificationsAsRead, markNotificationAsRead } from "@/api/notifications";
+import { queryKeys } from "@/lib/query-client";
+import { toast } from "sonner";
+
+/**
+ * 단일 알림 읽음 처리 훅
+ */
+export function useMarkNotificationAsRead() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: markNotificationAsRead,
+        onSuccess: () => {
+            // 목록 갱신
+            queryClient.invalidateQueries({ queryKey: queryKeys.notifications.all });
+        },
+        onError: (error) => {
+            console.error("Failed to mark notification as read:", error);
+            toast.error("알림 읽음 처리에 실패했습니다.");
+        },
+    });
+}
+
+/**
+ * 모든 알림 읽음 처리 훅
+ */
+export function useMarkAllAsRead() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: markAllNotificationsAsRead,
+        onSuccess: () => {
+            toast.success("모든 알림을 읽음 처리했습니다.");
+            queryClient.invalidateQueries({ queryKey: queryKeys.notifications.all });
+        },
+        onError: (error) => {
+            console.error("Failed to mark all notifications as read:", error);
+            toast.error("알림 전체 읽음 처리에 실패했습니다.");
+        },
+    });
+}

--- a/src/hooks/mutations/use-sign-out.ts
+++ b/src/hooks/mutations/use-sign-out.ts
@@ -14,27 +14,27 @@ import { trackEvent } from "@/lib/analytics";
  * 3. 로그인 페이지로 리다이렉트
  */
 export function useSignOut() {
-    const navigate = useNavigate();
-    const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
-    return useMutation({
-        mutationFn: signOut,
-        onSuccess: () => {
-            // 1. 이벤트 트래킹
-            trackEvent("user_sign_out");
+  return useMutation({
+    mutationFn: signOut,
+    onSuccess: () => {
+      // 1. 이벤트 트래킹
+      trackEvent("user_sign_out");
 
-            // 2. 모든 캐시 데이터 초기화 (보안 강화)
-            queryClient.clear();
+      // 2. 모든 캐시 데이터 초기화 (보안 강화)
+      queryClient.clear();
 
-            // 3. 사용자 피드백
-            toast.success("로그아웃되었습니다.");
+      // 3. 사용자 피드백
+      toast.success("로그아웃되었습니다.");
 
-            // 4. 페이지 이동 (뒤로가기 방지)
-            navigate(ROUTES.AUTH, { replace: true });
-        },
-        onError: (error: Error) => {
-            console.error("Sign out error:", error);
-            toast.error("로그아웃에 실패했습니다. 다시 시도해주세요.");
-        },
-    });
+      // 4. 페이지 이동 (뒤로가기 방지)
+      navigate(ROUTES.AUTH, { replace: true });
+    },
+    onError: (error: Error) => {
+      console.error("Sign out error:", error);
+      toast.error("로그아웃에 실패했습니다. 다시 시도해주세요.");
+    },
+  });
 }

--- a/src/hooks/queries/use-notifications.ts
+++ b/src/hooks/queries/use-notifications.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMyNotifications, getUnreadCount } from "@/api/notifications";
+import { queryKeys } from "@/lib/query-client";
+
+/**
+ * 내 알림 목록 조회 훅
+ */
+export function useNotifications(offset = 0, limit = 20) {
+    return useQuery({
+        queryKey: queryKeys.notifications.list(offset, limit),
+        queryFn: () => getMyNotifications({ offset, limit }),
+    });
+}
+
+/**
+ * 읽지 않은 알림 개수 조회 훅
+ *
+ * 30초마다 자동으로 갱신됩니다.
+ */
+export function useUnreadCount() {
+    return useQuery({
+        queryKey: queryKeys.notifications.unreadCount,
+        queryFn: getUnreadCount,
+        refetchInterval: 30000, // 30초마다 자동 갱신
+    });
+}

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -45,6 +45,11 @@ export const queryKeys = {
     list: (status?: string) => ["dm", "list", status],
     messages: (dmRoomId: string) => ["dm", "messages", dmRoomId],
   },
+  notifications: {
+    all: ["notifications"],
+    list: (offset?: number, limit?: number) => ["notifications", "list", offset, limit],
+    unreadCount: ["notifications", "unreadCount"],
+  },
 } as const;
 
 export const queryClient = new QueryClient({

--- a/src/pages/index-page.tsx
+++ b/src/pages/index-page.tsx
@@ -16,7 +16,6 @@ export default function IndexPage() {
       >
         🎈 터미널로 이동
       </button>
-
     </div>
   );
 }

--- a/src/pages/my-page.tsx
+++ b/src/pages/my-page.tsx
@@ -94,9 +94,7 @@ export default function MyPage() {
             className="flex w-full items-center gap-4 rounded-xl bg-zinc-900/50 px-4 py-4 transition-colors hover:bg-zinc-800/50 disabled:opacity-50"
           >
             <LogOut className="h-5 w-5 text-zinc-400" />
-            <span className="flex-1 text-left text-base">
-              {isSigningOut ? "로그아웃 중..." : "로그아웃"}
-            </span>
+            <span className="flex-1 text-left text-base">{isSigningOut ? "로그아웃 중..." : "로그아웃"}</span>
             <ChevronRight className="h-5 w-5 text-zinc-500" />
           </button>
         </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -418,3 +418,27 @@ export interface DailyLoginReward {
   claimed: boolean;
   created_at: string;
 }
+
+// ============================================================================
+// Notification (알림) 관련 타입
+// ============================================================================
+
+/** 알림 타입 */
+export type NotificationType =
+  | "CHECKOUT_REMINDER" // 체크아웃 알림
+  | "DM_REQUEST" // 대화 요청
+  | "ANNOUNCEMENT" // 공지사항
+  | "SYSTEM"; // 시스템 메시지
+
+/** 알림 정보 (백엔드 Notification 모델과 동일) */
+export interface Notification {
+  notification_id: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  is_read: boolean;
+  created_at: string;
+}
+
+/** 알림 목록 응답 */
+export interface NotificationListResponse extends ListResponse<Notification> { }


### PR DESCRIPTION
## Summary
- 터미널 헤더에 알림 Bell 아이콘 추가 및 알림 시트 구현

## Changes

### API Layer (`src/api/notifications.ts`)
- `getNotifications()` - 알림 목록 조회
- `getUnreadCount()` - 읽지 않은 알림 개수 조회
- `markAsRead()` - 알림 읽음 처리
- `markAllAsRead()` - 모든 알림 읽음 처리

### Components
- `NotificationSheet` - 알림 목록 사이드 시트
- `NotificationItem` - 개별 알림 카드 (타입별 아이콘 및 스타일)
- `Sheet` - Shadcn UI Sheet 컴포넌트 추가
- `TerminalHeader` - Bell 아이콘 버튼 추가 (읽지 않은 알림 카운트 배지)

### Hooks
- `useNotifications()` - 알림 목록 조회 쿼리 훅
- `useMarkNotificationRead()` - 알림 읽음 처리 mutation 훅

### Types
- `Notification` - 알림 데이터 타입
- `NotificationType` - 알림 타입 (ANNOUNCEMENT, DM_REQUEST, CHECKOUT_REMINDER, SYSTEM)
- `UnreadCountResponse` - 읽지 않은 알림 개수 응답 타입

## Features
- 터미널 헤더 우측에 Bell 아이콘 버튼 표시
- 읽지 않은 알림이 있으면 카운트 배지 표시
- Bell 아이콘 클릭 시 알림 시트 열림
- 알림 타입별 아이콘 및 색상 구분
- 개별 알림 클릭 시 읽음 처리
- "모두 읽음" 버튼으로 전체 읽음 처리

## Related Issue
Closes #109

## Notes
⚠️ **백엔드 API가 아직 구현되지 않았습니다.** 이 PR은 프론트엔드 UI/UX 구현만 포함하고 있으며, 백엔드 API 엔드포인트가 준비되면 정상 동작합니다.

백엔드에서 구현이 필요한 엔드포인트:
- `GET /notifications` - 알림 목록 조회
- `GET /notifications/unread-count` - 읽지 않은 알림 개수
- `PATCH /notifications/{id}/read` - 알림 읽음 처리
- `POST /notifications/read-all` - 모든 알림 읽음 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)